### PR TITLE
ECMFindModuleHelpers.cmake:  Use imported targets from pkg-config

### DIFF
--- a/modules/ECMFindModuleHelpers.cmake
+++ b/modules/ECMFindModuleHelpers.cmake
@@ -207,7 +207,11 @@ macro(ecm_find_package_handle_library_components module_name)
 
         if(NOT ECM_FPWC_SKIP_PKG_CONFIG AND ${module_name}_${ecm_fpwc_comp}_pkg_config)
             pkg_check_modules(PKG_${module_name}_${ecm_fpwc_comp} QUIET
+                              IMPORTED_TARGET
                               ${${module_name}_${ecm_fpwc_comp}_pkg_config})
+            if (TARGET PkgConfig::PKG_${module_name}_${ecm_fpwc_comp})
+                list(APPEND ecm_fpwc_dep_targets PkgConfig::PKG_${module_name}_${ecm_fpwc_comp})
+            endif()
         endif()
 
         find_path(${module_name}_${ecm_fpwc_comp}_INCLUDE_DIR


### PR DESCRIPTION
I was having trouble building Qt 6.4.1 for Linux and making it use a static version of XCB.  One of the problems was that the `xcb_syslibs` test in `src/gui/configure.cmake` was failing because we were not passing *all* the required linker arguments when linking a small test program that uses XCB.

Parts of XCB rely on libXau, so any program using a static version of XCB must remember to link in libXau.  The best way to do that is to run `pkg-config` and pay attention to *all* the flags it returns.  For example, in my environment (which I'd be happy to share with you as a Nix expression and help you use it), if I run `pkg-config-cross xcb  --libs`, the result is:

    -L/nix/store/gnq8lg2z7267g5awk1kwhap1lybx09a3-libxcb-1.13.1-i686-linux-musleabi/lib -lxcb -L/nix/store/ayijz2v117hwpzjhdnz5p9h8vxc9gl5p-libxau-1.0.8-i686-linux-musleabi/lib -lXau

Unfortunately, it seems like ECMFindModuleHelpers.cmake ignores most of the info returned by its calls to `pkg-config`.  It only uses those calls to get hints about things like where to find the include directory and the library file.  So it was totally missing the requirement to link to libXau, and I got the following error message when compiling a simple test program (which I'd be happy to share):

```text
[100%] Linking C executable test_find_xcb
/nix/store/xyys3fv9ysshd6cns0a4vwxm3j46zyph-libxall-i686-linux-musleabi/lib/libxcb.a(xcb_auth.o): In function `get_authptr':
/tmp/nix-build-libxcb-1.13.1-i686-linux-musleabi.drv-0/build/src/../../libxcb/src/xcb_auth.c:163: undefined reference to `XauGetBestAuthByAddr'
/nix/store/xyys3fv9ysshd6cns0a4vwxm3j46zyph-libxall-i686-linux-musleabi/lib/libxcb.a(xcb_auth.o): In function `_xcb_get_auth_info':
/tmp/nix-build-libxcb-1.13.1-i686-linux-musleabi.drv-0/build/src/../../libxcb/src/xcb_auth.c:377: undefined reference to `XauDisposeAuth'
/tmp/nix-build-libxcb-1.13.1-i686-linux-musleabi.drv-0/build/src/../../libxcb/src/xcb_auth.c:369: undefined reference to `XauDisposeAuth'
collect2: error: ld returned 1 exit status
```

My suggested solution is that ECMFindModuleHelpers.cmake should ask `pkg_check_modules` to make an imported target and then link to that target as a dependency.  In fact, if we can simply do that, most of the other work being done in ECMFindModuleHelpers.cmake is irrelevant.  If this were my project, I'd be trying to remove most of that code and just replace it with simple calls to `pkg_check_modules` that create an imported target.

The imported target feature is only availabe in CMake 3.6 and later, but I hope that isn't a problem.  Qt itself requires CMake 3.16 or later.